### PR TITLE
Move Skins folder default location to be on same level of Assets folder

### DIFF
--- a/Editor/Core/Components/Main/ShapeShifter.cs
+++ b/Editor/Core/Components/Main/ShapeShifter.cs
@@ -17,7 +17,7 @@ namespace Miniclip.ShapeShifter
                 if (skinsFolder == null)
                 {
                     skinsFolder = new DirectoryInfo(
-                        Application.dataPath + $"/../../{ShapeShifterConstants.SKINS_MAIN_FOLDER}/"
+                        Application.dataPath + $"/../{ShapeShifterConstants.SKINS_MAIN_FOLDER}/"
                     );
                     FileUtils.TryCreateDirectory(SkinsFolder.FullName);
                 }


### PR DESCRIPTION
Making sure the tool will work even if the unity project main folders are placed on the root of the repository as the Skins need to be inside the repository